### PR TITLE
Fix typo, remove stale OpenWeatherMapWeatherProvider reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,3 @@ The included APKs are:
    * GsfProxy: a GmsCore proxy for legacy GCM compatibility
    * FakeStore: an empty package that mocks the existence of the Google Play Store
    * com.google.android.maps: legacy microG's mapsv1 reimplementation
- * LineageOS packages (binaries sourced from [here](https://download.lineageos.org/extras))
-   * OpenWeatherMapWeatherProvider: "Open Weather Map" weather provider for the LineageOS' weather service
-

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The included APKs are:
  * FDroid packages (binaries sourced from [here](https://f-droid.org/packages/org.fdroid.fdroid/) and [here](https://f-droid.org/packages/org.fdroid.fdroid.privileged/))
    * FDroid: a catalogue of FOSS (Free and Open Source Software) applications for the Android platform
    * FDroid Privileged Extension: a FDroid extension to ease the installation/removal of apps
-   * additional_repos.xmly: a simple package to include the [microG FDroid repository](https://microg.org/fdroid.html) in the ROM (requires FDroid >= 1.5)
+   * additional_repos.xml: a simple package to include the [microG FDroid repository](https://microg.org/fdroid.html) in the ROM (requires FDroid >= 1.5)
  * microG packages (binaries sourced from [here](https://microg.org/download.html) and [here](https://github.com/microg/android_frameworks_mapsv1))
    * GmsCore: the main component of microG, a FOSS reimplementation of the Google Play Services (requires GsfProxy and FakeStore for full functionality)
    * GsfProxy: a GmsCore proxy for legacy GCM compatibility


### PR DESCRIPTION
This PR fixes a minor typo and removes the reference to OpenWeatherMapWeatherProvider from README.md as the referenced apk is not actually included in the repo (and it's not available for Lineage 17.1). 